### PR TITLE
feat: projection options

### DIFF
--- a/config/event_store.php
+++ b/config/event_store.php
@@ -1,5 +1,7 @@
 <?php
 
+use Prooph\EventStore\Projection\Projector;
+
 return [
     /*
     |--------------------------------------------------------------------------
@@ -83,6 +85,7 @@ return [
     | The necessary definitions for creating projections
     | - store: The name of the store. One of mysql, maria_db or postgres
     | - event_streams_table: Defaults to event_streams
+    | - options: Set the projection options. See the `Prooph\EventStore\Projection\Projector` constants for options
     | - projections_table: Defaults to projections
     | - projections
     |   - connection: The name of the connection to use. Defaults to the same connection as the store.
@@ -93,6 +96,10 @@ return [
     'projection_managers' => [
         'default' => [
             'store' => 'default',
+            'options' => [
+                Projector::OPTION_LOCK_TIMEOUT_MS => Projector::DEFAULT_LOCK_TIMEOUT_MS,
+                Projector::OPTION_UPDATE_LOCK_THRESHOLD => Projector::DEFAULT_UPDATE_LOCK_THRESHOLD,
+            ],
             'projections' => [
             ]
         ]

--- a/src/Command/AbstractProjectionCommand.php
+++ b/src/Command/AbstractProjectionCommand.php
@@ -56,12 +56,14 @@ class AbstractProjectionCommand extends Command
         $this->projectionManager = app()->make(ProjectionManagerFactory::class)->managerFor($this->projectionName);
         $this->projection        = app()->make('event_store.projection.' . $this->projectionName . '.projection');
 
+        $projectionOptions = app()->make(ProjectionManagerFactory::class)->optionsFor($this->projectionName);
+
         if ($this->projection instanceof ReadModelProjection) {
             $this->readModel = app()->make('event_store.projection.' . $this->projectionName . '.read_model');
 
-            $this->projector = $this->projectionManager->createReadModelProjection($this->projectionName, $this->readModel);
+            $this->projector = $this->projectionManager->createReadModelProjection($this->projectionName, $this->readModel, $projectionOptions);
         } else {
-            $this->projector = $this->projectionManager->createProjection($this->projectionName);
+            $this->projector = $this->projectionManager->createProjection($this->projectionName, $projectionOptions);
         }
     }
 }

--- a/src/Factory/ProjectionManagerFactory.php
+++ b/src/Factory/ProjectionManagerFactory.php
@@ -68,7 +68,7 @@ class ProjectionManagerFactory implements ProjectionManagerFactoryContract
     public function managerFor(string $projection): ProjectionManager
     {
         foreach ($this->app->make('config')->get('event_store.projection_managers') as $name => $config) {
-            if (in_array($projection, array_keys($config['projections']))) {
+            if (array_key_exists($projection, $config['projections'])) {
                 return $this->make($name);
             }
         }
@@ -78,12 +78,12 @@ class ProjectionManagerFactory implements ProjectionManagerFactoryContract
 
     public function optionsFor(string $projection) {
         foreach ($this->app->make('config')->get('event_store.projection_managers') as $name => $config) {
-            if (in_array($projection, array_keys($config['projections']))) {
+            if (array_key_exists($projection, $config['projections'])) {
                 return $config['options'] ?? [];
             }
         }
 
-        throw new RuntimeException('No options for projection ' . $projection);
+        return [];
     }
 
     public function buildPdoManager(string $name, array $config): ProjectionManager

--- a/src/Factory/ProjectionManagerFactory.php
+++ b/src/Factory/ProjectionManagerFactory.php
@@ -76,6 +76,16 @@ class ProjectionManagerFactory implements ProjectionManagerFactoryContract
         throw new RuntimeException('No projection manager for projection ' . $projection);
     }
 
+    public function optionsFor(string $projection) {
+        foreach ($this->app->make('config')->get('event_store.projection_managers') as $name => $config) {
+            if (in_array($projection, array_keys($config['projections']))) {
+                return $config['options'] ?? [];
+            }
+        }
+
+        throw new RuntimeException('No options for projection ' . $projection);
+    }
+
     public function buildPdoManager(string $name, array $config): ProjectionManager
     {
         $eventStore = $this->app->make('event_store')->store($config['store']);

--- a/src/Factory/ProjectionManagerFactory.php
+++ b/src/Factory/ProjectionManagerFactory.php
@@ -76,7 +76,8 @@ class ProjectionManagerFactory implements ProjectionManagerFactoryContract
         throw new RuntimeException('No projection manager for projection ' . $projection);
     }
 
-    public function optionsFor(string $projection) {
+    public function optionsFor(string $projection): array
+    {
         foreach ($this->app->make('config')->get('event_store.projection_managers') as $name => $config) {
             if (array_key_exists($projection, $config['projections'])) {
                 return $config['options'] ?? [];


### PR DESCRIPTION
Currently there's no way to specify projection options. This means by default every projector writes a lock update every 100ms. As you can imagine, with lots of projectors running this gets very very bad.

This allows customisation. I'd put forward the proposal to set the timeouts to something more sane by default but have left them as is in this PR.